### PR TITLE
Fix clone location info

### DIFF
--- a/src/ca/concordia/jdeodorant/clone/parsers/CloneDetectorOutputParser.java
+++ b/src/ca/concordia/jdeodorant/clone/parsers/CloneDetectorOutputParser.java
@@ -11,6 +11,7 @@ import org.eclipse.jdt.core.ICompilationUnit;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jdt.core.IJavaProject;
 import org.eclipse.jdt.core.IMethod;
+import org.eclipse.jdt.core.IType;
 import org.eclipse.jdt.core.JavaModelException;
 import org.eclipse.jdt.core.Signature;
 import org.eclipse.jdt.core.dom.ASTNode;
@@ -212,6 +213,10 @@ public abstract class CloneDetectorOutputParser {
 				e.printStackTrace();
 			}
 			cloneInstance.setMethodSignature(getMethodJavaSignature(iMethod));
+			IJavaElement parent = iMethod.getParent();
+			if (parent instanceof IType) {
+				cloneInstance.setContainingClassFullyQualifiedName(((IType)parent).getFullyQualifiedName());
+			}
 		}
 		return cloneInstance;
 	}

--- a/src/ca/concordia/jdeodorant/clone/parsers/CloneGroup.java
+++ b/src/ca/concordia/jdeodorant/clone/parsers/CloneGroup.java
@@ -133,7 +133,9 @@ public class CloneGroup {
 		Set<String> uniqueCloneMethodIMethods = new HashSet<String>();
 		for (CloneInstance instance : cloneInstances) {
 			uniqueCloneCodeFragmentsSourceFiles.add(instance.getLocationInfo().getContainingFilePath());
-			uniqueCloneMethodIMethods.add(instance.getIMethodSignature());
+			uniqueCloneMethodIMethods.add(instance.getContainingClassFullyQualifiedName() + "#" +
+					instance.getMethodName() + ":" +
+					instance.getIMethodSignature());
 		}
 		if (uniqueCloneCodeFragmentsSourceFiles.size() == 1) {
 			if (uniqueCloneMethodIMethods.size() == 1) {

--- a/src/ca/concordia/jdeodorant/clone/parsers/CloneInstance.java
+++ b/src/ca/concordia/jdeodorant/clone/parsers/CloneInstance.java
@@ -5,13 +5,13 @@ public class CloneInstance {
 	private CloneGroup belongingCloneGroup;
 	private final CloneInstanceLocationInfo locationInfo;
 	private int cloneID;
-	private String sourceFolder;
-	private String packageName;
-	private String className;
-	private String iMethodSignature;
-	private String methodSignature;
-	private String methodName;
-	private String containingClassFullyQualifiedName;
+	private String sourceFolder = "";
+	private String packageName = "";
+	private String className = "";
+	private String iMethodSignature = "";
+	private String methodSignature = "";
+	private String methodName = "";
+	private String containingClassFullyQualifiedName = "";
 	private final String originalCodeFragment;
 	
 	public CloneInstance(CloneInstanceLocationInfo locationInfo, int cloneID) {

--- a/src/ca/concordia/jdeodorant/clone/parsers/CloneInstance.java
+++ b/src/ca/concordia/jdeodorant/clone/parsers/CloneInstance.java
@@ -11,6 +11,7 @@ public class CloneInstance {
 	private String iMethodSignature;
 	private String methodSignature;
 	private String methodName;
+	private String containingClassFullyQualifiedName;
 	private final String originalCodeFragment;
 	
 	public CloneInstance(CloneInstanceLocationInfo locationInfo, int cloneID) {
@@ -158,5 +159,13 @@ public class CloneInstance {
 		if (newStartOffset >= 0)
 			newEndOffset = newStartOffset + originalCodeFragment.length() - 1;
 		return updateOffsets(newStartOffset, newEndOffset);
+	}
+
+	public void setContainingClassFullyQualifiedName(String parentFullyQualifiedName) {
+		this.containingClassFullyQualifiedName = parentFullyQualifiedName;
+	}
+	
+	public String getContainingClassFullyQualifiedName() {
+		return containingClassFullyQualifiedName;
 	}
 }


### PR DESCRIPTION
In CloneInstance, we used to keep only the top-level type enclosing the clone fragments. In the Excel files that we generate by running commandline we also show this top-level type name. Now we also keep the fully-qualified path to the real parent (even if it's a nested class). We get it from the enclosing IMethod's parent IType. If the enclosing IMethod is null (say the clone is in a weird location), the changes should not throw an NPE because I initialised the corresponding fields in CloneInstance with empty string. 

This allows finding the correct relative location info in CloneGroup, i.e., this should fix #23 .

This is off JLS8-support, should we cherry-pick it to master?
